### PR TITLE
Fix #21: On desktop the top row indicators are a bit too big to fit on the page

### DIFF
--- a/PurposeInvestmentBreakdown.html
+++ b/PurposeInvestmentBreakdown.html
@@ -602,6 +602,12 @@ width: 1px;
 background: var(--border);
 flex-shrink: 0;
 }
+.top-row-primary .top-row-item {
+flex: 1 1 auto;
+}
+.top-row-primary .summary-value {
+font-size: 26px;
+}
 .coverage-row {
 background: var(--card-bg);
 border: 1px solid var(--border);
@@ -1012,7 +1018,7 @@ dbg('6. holdingsTable on window.load: ' + (tbl ? 'FOUND, childCount=' + tbl.chil
 
   <!-- Row 1: Facts -->
 
-  <div class="top-row">
+  <div class="top-row top-row-primary">
     <div class="top-row-item">
       <div class="summary-label">Shares Held</div>
       <input class="position-input" id="sharesInput" type="number" min="0" placeholder="0" oninput="onSharesInput(this.value)">


### PR DESCRIPTION
## Summary

- Added `top-row-primary` class to the 4-item Row 1 so it can be targeted independently of Row 2
- Added `.top-row-primary .top-row-item { flex: 1 1 auto; }` so the four items share the available row width instead of overflowing/clipping
- Added `.top-row-primary .summary-value { font-size: 26px; }` to reduce the value font size from 32px → 26px

Row 2 (Est. Fund Move / Est. Position P&L) is intentionally unchanged per the agreed plan.

Closes #21