### PR TITLE
Fix #21: On desktop the top row indicators are a bit too big to fit on the page

### DIFF
--- a/PurposeInvestmentBreakdown.html
+++ b/PurposeInvestmentBreakdown.html
@@ -588,19 +588,20 @@ opacity: 0;
 .top-row {
 display: flex;
 align-items: stretch;
-background: var(--card-bg);
+background: var(--border);
 border: 1px solid var(--border);
 overflow: hidden;
 margin-bottom: 6px;
+flex-wrap: wrap;
+gap: 1px;
 }
 .top-row-item {
 padding: 18px 20px;
-flex: 0 0 auto;
+flex: 0 1 auto;
+background: var(--card-bg);
 }
 .top-row-divider {
-width: 1px;
-background: var(--border);
-flex-shrink: 0;
+display: none;
 }
 .coverage-row {
 background: var(--card-bg);


### PR DESCRIPTION
## Summary

Closes #21

The three `.top-row` indicator sections (commodities, facts, estimates) were overflowing their 940 px container on desktop because `.top-row-item` was set to `flex: 0 0 auto` (no shrinking, no wrapping) and the sum of item widths exceeded the container width.

### Changes (CSS only, `PurposeInvestmentBreakdown.html`)

- **`.top-row`** — added `flex-wrap: wrap` and `gap: 1px`, changed `background` from `var(--card-bg)` to `var(--border)`. The 1 px gap acts as the column divider between items (showing the border colour through the container background) and as a row separator when items wrap.
- **`.top-row-item`** — changed `flex: 0 0 auto` → `flex: 0 1 auto` (items now shrink before wrapping) and added explicit `background: var(--card-bg)` (needed since the container background changed).
- **`.top-row-divider`** — set to `display: none`; the gap-based approach replaces the separate divider elements visually.

### Agreed approach (from issue thread)

- **Scope:** all 3 `.top-row` sections ✓
- **Behaviour:** items shrink to their minimum content size first, then wrap to a new line ✓
- Existing mobile media queries (`≤ 640 px` and `≤ 900 px landscape`) are unaffected.

https://claude.ai/code/session_01NTGAXKbG3GtLSWuHTPhwnU